### PR TITLE
build: Fix unknown plugin error

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         maven { url 'https://repo.spring.io/release' }
+        maven { url 'https://repo.spring.io/milestone' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,10 +2,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        maven { url 'https://repo.spring.io/release' }
+        mavenCentral()
         maven { url 'https://repo.spring.io/milestone' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
     }
 }
 
@@ -14,7 +13,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://repo.spring.io/release' }
+        maven { url 'https://repo.spring.io/milestone' }
         maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }


### PR DESCRIPTION
Repo for Spring Native AOT has changed since Feb 2023.

This PR reflects that change as merge is blocked on CI failure.